### PR TITLE
[Build] Fix mapping of 'queue.fibonacci_heap'

### DIFF
--- a/extras/make-release.py
+++ b/extras/make-release.py
@@ -50,7 +50,7 @@ mdReplacements =	('%MinchinWeb', 'MinchinWeb'), \
 					('←', '<-')
 					
 aiReplacements = \
-	('"queue.fibonacci_heap", "", 3);'	  ,'"queue.fibonacci_heap", "", 2' ), \
+	('"queue.fibonacci_heap", "", 3);'	  ,'"queue.fibonacci_heap", "", 2);' ), \
 	('Fibonacci Heap v.3'				  ,'Fibonacci Heap v.2'			   ), \
 	("AIAccounting"						  ,"GSAccounting"                  ), \
 	("AIAirport"                          ,"GSAirport"                     ), \


### PR DESCRIPTION
There was a missing bracket and semicolon from the string. This prevented the script compiling when used in NoGS.
